### PR TITLE
Changed getter style to say "getter must have no side effects"

### DIFF
--- a/style.md
+++ b/style.md
@@ -547,11 +547,9 @@ should use `public`, but AngularJS should use `protected`.
 > Warning: Getters and setters have to be transpiled into bloated code.
 > It is a good practice to avoid using getters and setters in general.
 
-Getters and setters for class members may be used. The getter method must be a
-[pure function](https://en.wikipedia.org/wiki/Pure_function) (i.e., result is
-consistent and has no side effects). They are also useful as a means of
-restricting the visibility of internal or verbose implementation details (shown
-below).
+Getters and setters for class members may be used. The getter method must have 
+no side effects. They are also useful as a means of restricting the visibility
+of internal or verbose implementation details (shown below).
 
 ```ts {.good}
 class Foo {


### PR DESCRIPTION
Changed getter style to say 
> The getter method must have no side effects

instead of

> The getter method must be a pure function(i.e., result is consistent and has no side effects)

Getters are inherently impure.  A pure function with no params will return a constant value.