### PR TITLE
fix(docs): Changed Member property declarations interface

### DIFF
--- a/style.md
+++ b/style.md
@@ -1395,8 +1395,8 @@ symmetry with class declarations:
 
 ```ts {.bad}
 interface Foo {
-  memberA: string;
-  memberB: number;
+  memberA: string,
+  memberB: number,
 }
 ```
 


### PR DESCRIPTION
Changed Member property declarations interface bad code example symbols:
from semicolon `;` to comma `,`